### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Report a bug encountered while using Yorkie
+labels: bug 🐞
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Operating system:
+- Browser and version:
+- Yorkie version (use `yorkie version`):
+- Yorkie JS SDK version:

--- a/.github/ISSUE_TEMPLATE/common-issue.md
+++ b/.github/ISSUE_TEMPLATE/common-issue.md
@@ -1,0 +1,11 @@
+---
+name: Common Issue
+about: A common issue with the Yorkie project
+labels:
+
+---
+<!-- Please only use this template for submitting common issues -->
+
+**Description**:
+
+**Why**:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the Yorkie project
+labels: enhancement 🌟
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:


### PR DESCRIPTION
<!-- Please only use this template for submitting common issues -->

**Description**:

We can customize the templates that are available for contributors to use when they open new issues in the repository.

**Why**:

Issue Templates help us maintain a consistent format as issues are created. This makes tracking and managing issues in our project easier.